### PR TITLE
Fix overlapping issue of min/max slider's handles

### DIFF
--- a/Assets/DoubleSlider/Scripts/DoubleSlider.cs
+++ b/Assets/DoubleSlider/Scripts/DoubleSlider.cs
@@ -114,6 +114,7 @@ namespace TS.DoubleSlider
             }
 
             OnValueChanged.Invoke(MinValue, MaxValue);
+            _sliderMin.transform.SetAsLastSibling();
         }
         private void MaxValueChanged(float value)
         {
@@ -127,6 +128,7 @@ namespace TS.DoubleSlider
             }
 
             OnValueChanged.Invoke(MinValue, MaxValue);
+            _sliderMax.transform.SetAsLastSibling();
         }
     }
 }

--- a/Assets/DoubleSlider/Scripts/SingleSlider.cs
+++ b/Assets/DoubleSlider/Scripts/SingleSlider.cs
@@ -61,6 +61,8 @@ namespace TS.DoubleSlider
             _slider.value = value;
             _slider.onValueChanged.AddListener(Slider_OnValueChanged);
             _slider.onValueChanged.AddListener(valueChanged);
+
+            UpdateLabel();
         }
 
         private void Slider_OnValueChanged(float arg0)


### PR DESCRIPTION
If setting the min distance to zero, a bug occurs when the max and min sliders reach their maximum values. This can be resolved by adjusting the sibling order of the last interacted handle to the last sibling.